### PR TITLE
Make transformers stateless, fixes Sponge Mixins compatibility

### DIFF
--- a/src/main/java/ru/fewizz/neid/asm/Transformer.java
+++ b/src/main/java/ru/fewizz/neid/asm/Transformer.java
@@ -1,24 +1,30 @@
 package ru.fewizz.neid.asm;
 
-import java.util.*;
-
-import org.apache.logging.log4j.*;
-import org.objectweb.asm.*;
-import org.objectweb.asm.tree.ClassNode;
-
 import net.minecraft.launchwrapper.IClassTransformer;
-import ru.fewizz.neid.asm.group.block.*;
-import ru.fewizz.neid.asm.group.item.*;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.tree.ClassNode;
+import ru.fewizz.neid.asm.group.block.TransformerGroupAnvilChunkLoader;
+import ru.fewizz.neid.asm.group.block.TransformerGroupBlockHardcoredConstants;
+import ru.fewizz.neid.asm.group.block.TransformerGroupChunkPrimer;
+import ru.fewizz.neid.asm.group.block.TransformerGroupWorldEdit;
+import ru.fewizz.neid.asm.group.item.TransformerGroupItemHardcoredConstants;
+import ru.fewizz.neid.asm.group.item.TransformerGroupPacketBuffer;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 public class Transformer implements IClassTransformer {
 	public static final Logger LOGGER = LogManager.getLogger("neid");
 	public static boolean envDeobfuscated;
-	private ClassNode cn;
-	private ClassReader cr;
-	private ClassWriter cw;
-	private List<TransformerGroup> transformerGroups;
 
-	public Transformer() {
+	private static List<TransformerGroup> transformerGroups;
+
+	static {
 		transformerGroups = new ArrayList<>();
 
 		// Block
@@ -30,54 +36,37 @@ public class Transformer implements IClassTransformer {
 		// Item
 		addTransformerGroup(new TransformerGroupItemHardcoredConstants());
 		addTransformerGroup(new TransformerGroupPacketBuffer());
+
+		transformerGroups = Collections.unmodifiableList(transformerGroups);
 	}
 
-	private void addTransformerGroup(TransformerGroup group) {
+	private static void addTransformerGroup(TransformerGroup group) {
 		transformerGroups.add(group);
 	}
 
 	@Override
 	public byte[] transform(String name, String deobfName, byte[] bytes) {
-		boolean transformed = false;
 
-		for (Iterator<TransformerGroup> it = transformerGroups.iterator(); it.hasNext();) {
-			TransformerGroup tg = it.next();
-
+		for (TransformerGroup tg : transformerGroups) {
 			for (Name clazz : tg.getRequiredClasses()) {
 				if (clazz.deobfDotted.equals(deobfName)) {
-					if (!transformed) {
-						transformed = true;
-						start(bytes, deobfName, tg);
-					}
+					ClassNode cn = new ClassNode(Opcodes.ASM5);
+
+					ClassReader cr = new ClassReader(bytes);
+					cr.accept(cn, 0);
 
 					LOGGER.info("Patching class: \"" + deobfName + "\" with Transformer Group: \"" + tg.getClass().getSimpleName() + "\"");
 					tg.startTransform(cn, clazz);
 
-					if (tg.isPatchedAllClasses()) {
-						it.remove();
-						break;
-					}
+					ClassWriter cw = new ClassWriter(0);
+					cn.accept(cw);
+
+					return cw.toByteArray();
 				}
 			}
 		}
 
-		if (transformed) {
-			end();
-			return cw.toByteArray();
-		}
-
 		return bytes;
-	}
-
-	void start(byte[] bytes, String name, TransformerGroup tg) {
-		cn = new ClassNode(Opcodes.ASM5);
-		cr = new ClassReader(bytes);
-		cr.accept(cn, 0);
-	}
-
-	void end() {
-		cw = new ClassWriter(0);
-		cn.accept(cw);
 	}
 
 }

--- a/src/main/java/ru/fewizz/neid/asm/TransformerGroup.java
+++ b/src/main/java/ru/fewizz/neid/asm/TransformerGroup.java
@@ -4,21 +4,8 @@ import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.tree.ClassNode;
 
 public abstract class TransformerGroup implements Opcodes {
-	int done = 0;
 	final Name[] requiredClasses = getRequiredClassesInternal();
 	final int needToDo = requiredClasses.length;
-	
-	public int getPatchedClassesCount() {
-		return done;
-	}
-	
-	public void increasePatchedClassesCount() {
-		done++;
-	}
-	
-	public boolean isPatchedAllClasses() {
-		return done >= needToDo;
-	}
 	
 	public Name[] getRequiredClasses() {
 		return requiredClasses;
@@ -30,6 +17,5 @@ public abstract class TransformerGroup implements Opcodes {
 	
 	public void startTransform(ClassNode cn, Name clazz) {
 		transform(cn, clazz);
-		increasePatchedClassesCount();
 	}
 }


### PR DESCRIPTION
One of the contracts of class transformers is that they must be stateless (as they will be called from other threads, etc). Currently, the transformer implementation is stateful, introducing safety bugs and other issues, such as breaking Sponge Mixin compatibility entirely. If another mod mixes a class which NotEnoughIDs targets, it will not be transformed by NEID despite still being compatible.

This is because the transformer in NotEnoughIDs will be called by Sponge before execution on a real class, which will cause NotEnoughIDs to [un-register the transformer group](https://github.com/fewizz/NotEnoughIDs/blob/1.12.x/src/main/java/ru/fewizz/neid/asm/Transformer.java#L56) after it finishes patching the fake class. 

This merge request fixes the issue and makes the implementation more resilient. For previous discussion on this issue, please see [the issue opened with Phosphor](https://gitea.gildedgames.com/jellysquid/Phosphor/issues/10). 